### PR TITLE
Additional Predicates on the Command Line Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ This file contains the notable changes in the ISLa project since version 0.2a1
 
 ## [unreleased]
 
+### Added
+
+- It is now possible to extend ISLa with custom structural or semantic predicates when
+  using the CLI (this concerns `isla solve`, `isla parse`, `isla check`, `isla fuzz`,
+  `isla mutate`, `isla find`, and `isla mutate`) by passing a Python file as input
+  that contains a function
+
+  ```python
+  predicates() -> typing.Set[isla.language.StructuralPredicate | isla.language.SemanticPredicate]
+  ```
+  
+  Additionally or alternatively, that file may define a variable `grammar` specifying
+  the grammar of the language under test. This behavior, already implemented in previous
+  ISLa versions, is unaffected by the predicate extension feature.
+
 ## [1.8.0] - 2022-10-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file contains the notable changes in the ISLa project since version 0.2a1
 
 ## [unreleased]
 
+## [1.9.0] - 2022-11-08
+
 ### Added
 
 - It is now possible to extend ISLa with custom structural or semantic predicates when
@@ -16,9 +18,17 @@ This file contains the notable changes in the ISLa project since version 0.2a1
   predicates() -> typing.Set[isla.language.StructuralPredicate | isla.language.SemanticPredicate]
   ```
   
-  Additionally or alternatively, that file may define a variable `grammar` specifying
-  the grammar of the language under test. This behavior, already implemented in previous
-  ISLa versions, is unaffected by the predicate extension feature.
+  Additionally or alternatively, that file may define a variable `grammar` or a function
+  `grammar()` specifying the grammar of the language under test. This behavior, already
+  implemented in previous ISLa versions (for the variable declaration, see "Changed"),
+  is unaffected by the predicate extension feature.
+
+### Changed
+
+- In Python extension files, grammars may *alternatively* be defined as the return
+  value of a function `def grammar() -> Dict[str, List[str]]` instead of an assignment
+  to a variable `grammar`. This is the preferred style; the variable assignment may get
+  deprecated in the future.
 
 ## [1.8.0] - 2022-10-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "isla-solver"
-version = "1.8.0"
+version = "1.9.0"
 authors = [
     { name = "Dominic Steinhöfel", email = "dominic.steinhoefel@cispa.de" },
 ]

--- a/src/isla/__init__.py
+++ b/src/isla/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with ISLa.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"

--- a/src/isla/cli.py
+++ b/src/isla/cli.py
@@ -17,6 +17,8 @@
 # along with ISLa.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import collections.abc
+import functools
 import json
 import logging
 import os
@@ -26,8 +28,9 @@ import sys
 from argparse import Namespace, ArgumentParser
 from contextlib import redirect_stdout, redirect_stderr
 from functools import lru_cache
+from functools import partial
 from io import TextIOWrapper
-from typing import Dict, Tuple, List, Optional, Iterable
+from typing import Dict, Tuple, List, Optional, Iterable, cast, Any, Callable, Set
 
 import toml
 from grammar_graph import gg
@@ -46,7 +49,7 @@ from isla.isla_predicates import (
     STANDARD_SEMANTIC_PREDICATES,
 )
 from isla.isla_shortcuts import true
-from isla.language import parse_bnf, parse_isla
+from isla.language import parse_bnf, parse_isla, StructuralPredicate, SemanticPredicate
 from isla.solver import (
     ISLaSolver,
     GrammarBasedBlackboxCostComputer,
@@ -119,7 +122,19 @@ def solve(stdout, stderr, parser: ArgumentParser, args: Namespace):
         assert_path_is_dir(stderr, command, output_dir)
 
     grammar = parse_grammar(command, args.grammar, files, stderr)
-    constraint = parse_constraint(command, args.constraint, files, grammar, stderr)
+    # TODO: Also integrate predicates into other commands.
+    # TODO: Adapt help text; python files are not more general "extension" files
+    #       supplying grammars and/or predicates.
+    structural_predicates, semantic_predicates = read_predicates(files, stderr)
+    constraint = parse_constraint(
+        command,
+        args.constraint,
+        files,
+        grammar,
+        stderr,
+        structural_predicates=structural_predicates,
+        semantic_predicates=semantic_predicates,
+    )
     cost_computer = parse_cost_computer_spec(
         command, grammar, args.k, stderr, args.weight_vector
     )
@@ -134,6 +149,8 @@ def solve(stdout, stderr, parser: ArgumentParser, args: Namespace):
         timeout_seconds=args.timeout if args.timeout > 0 else None,
         activate_unsat_support=args.unsat_support,
         grammar_unwinding_threshold=args.unwinding_depth,
+        structural_predicates=structural_predicates,
+        semantic_predicates=semantic_predicates
     )
 
     try:
@@ -178,6 +195,41 @@ def solve(stdout, stderr, parser: ArgumentParser, args: Namespace):
             i += 1
     except KeyboardInterrupt:
         sys.exit(0)
+
+
+def read_predicates(
+    files: Dict[str, str], stderr
+) -> Tuple[Set[StructuralPredicate], Set[SemanticPredicate]]:
+    """
+    Executes a Python extension file, if any, and extracts predicates defined there.
+    Returns those together with the standard predicates.
+    :param files: The passed files (mapping from names to contents).
+    :param stderr: Standard error sink.
+    :return: The predicates.
+    """
+
+    _, maybe_structural_predicates, maybe_semantic_predicates = (
+        Maybe.from_iterator(
+            file_content
+            for file_name, file_content in files.items()
+            if file_name.endswith(".py")
+        )
+        .map(
+            lambda file_content: process_python_extension("solve", file_content, stderr)
+        )
+        .orelse(lambda: (Maybe.nothing(), Maybe.nothing(), Maybe.nothing()))
+    ).get()
+
+    structural_predicates = (
+        STANDARD_STRUCTURAL_PREDICATES
+        | maybe_structural_predicates.orelse(lambda: set()).get()
+    )
+    semantic_predicates = (
+        STANDARD_SEMANTIC_PREDICATES
+        | maybe_semantic_predicates.orelse(lambda: set()).get()
+    )
+
+    return structural_predicates, semantic_predicates
 
 
 def fuzz(_, stderr, parser: ArgumentParser, args: Namespace):
@@ -576,6 +628,8 @@ def parse_constraint(
     files: Dict[str, str],
     grammar: Grammar,
     stderr,
+    structural_predicates: Set[StructuralPredicate] = STANDARD_STRUCTURAL_PREDICATES,
+    semantic_predicates: Set[SemanticPredicate] = STANDARD_SEMANTIC_PREDICATES,
 ) -> language.Formula:
     constraint_arg = constraint_arg or []
     assert isinstance(constraint_arg, list)
@@ -588,8 +642,8 @@ def parse_constraint(
             with redirect_stderr(stderr):
                 constraint &= parse_isla(
                     constraint_str,
-                    structural_predicates=STANDARD_STRUCTURAL_PREDICATES,
-                    semantic_predicates=STANDARD_SEMANTIC_PREDICATES,
+                    structural_predicates=structural_predicates,
+                    semantic_predicates=semantic_predicates,
                     grammar=grammar,
                 )
 
@@ -598,8 +652,8 @@ def parse_constraint(
                 with redirect_stderr(stderr):
                     constraint &= parse_isla(
                         constraint_file.read(),
-                        structural_predicates=STANDARD_STRUCTURAL_PREDICATES,
-                        semantic_predicates=STANDARD_SEMANTIC_PREDICATES,
+                        structural_predicates=structural_predicates,
+                        semantic_predicates=semantic_predicates,
                         grammar=grammar,
                     )
     except Exception as exc:
@@ -632,17 +686,23 @@ def parse_grammar(
                         if grammar_file_name.endswith(".bnf"):
                             grammar |= parse_bnf(grammar_file_content)
                         else:
-                            locals_ = {}
-                            exec(grammar_file_content, {}, locals_)
-                            if "grammar" not in locals_:
-                                print(
-                                    f"isla {subcommand}: error: a Python grammar does "
-                                    + "not declare a variable `grammar`",
-                                    file=stderr,
-                                )
-                                sys.exit(DATA_FORMAT_ERROR)
+                            grammar |= (
+                                process_python_extension(
+                                    subcommand, grammar_file_content, stderr
+                                )[0]
+                                .orelse(lambda: {})
+                                .get()
+                            )
 
-                            grammar |= locals_["grammar"]
+            if not grammar:
+                print(
+                    "Could not find any grammar definition in the given files "
+                    + f"{', '.join(files)}; either supply a BNF grammar as file "
+                    + "(`*.bnf`) or command line argument, or a Python grammar "
+                    + " as file(`*.py`) defining a variable `grammar`.",
+                    file=stderr,
+                )
+                sys.exit(USAGE_ERROR)
 
     except Exception as exc:
         exc_string = str(exc)
@@ -654,7 +714,74 @@ def parse_grammar(
             file=stderr,
         )
         sys.exit(DATA_FORMAT_ERROR)
+
     return grammar
+
+
+def process_python_extension(
+    subcommand: str, python_file_content: str, stderr
+) -> Tuple[
+    Maybe[Grammar], Maybe[Set[StructuralPredicate]], Maybe[Set[SemanticPredicate]]
+]:
+    locals_ = {}
+    exec(python_file_content, {}, locals_)
+
+    grammar = cast(Maybe[Grammar], Maybe(locals_.get("grammar", None)))
+
+    def assert_is_function(maybe_function: Any) -> Callable:
+        if not callable(maybe_function):
+            print(
+                f"isla {subcommand}: error: symbol `predicate` in Python extension "
+                + "file is not a function.",
+                file=stderr,
+            )
+            sys.exit(DATA_FORMAT_ERROR)
+
+        return maybe_function
+
+    def assert_is_set_of_predicates(
+        maybe_set_of_predicates: Any,
+    ) -> Set[StructuralPredicate | SemanticPredicate]:
+        if not isinstance(maybe_set_of_predicates, collections.abc.Iterable):
+            print(
+                f"isla {subcommand}: error: function `predicate` in Python extension "
+                + "file does not return an iterable.",
+                file=stderr,
+            )
+            sys.exit(DATA_FORMAT_ERROR)
+
+        if any(
+            not isinstance(elem, StructuralPredicate)
+            and not isinstance(elem, SemanticPredicate)
+            for elem in maybe_set_of_predicates
+        ):
+            print(
+                f"isla {subcommand}: error: function `predicate` in Python extension "
+                + "file does not return an iterable of predicates.",
+                file=stderr,
+            )
+            sys.exit(DATA_FORMAT_ERROR)
+
+        return set(maybe_set_of_predicates)
+
+    predicates = (
+        Maybe(locals_.get("predicates"))
+        .map(assert_is_function)
+        .map(lambda f: f())
+        .map(assert_is_set_of_predicates)
+    )
+
+    structural_predicates = cast(
+        Maybe[Set[StructuralPredicate]],
+        predicates.map(partial(filter, StructuralPredicate.__instancecheck__)).map(set),
+    )
+
+    semantic_predicates = cast(
+        Maybe[Set[SemanticPredicate]],
+        predicates.map(partial(filter, SemanticPredicate.__instancecheck__)).map(set),
+    )
+
+    return grammar, structural_predicates, semantic_predicates
 
 
 def parse_cost_computer_spec(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,6 +257,62 @@ exists <assgn> assgn:
         grammar_file.close()
         constraint_file.close()
 
+    def test_solve_assgn_lang_python_grammar_as_function(self):
+        grammar_1_text = r"""
+from typing import Dict, List
+
+def grammar() -> Dict[str, List[str]]:
+    return {
+        "<start>": ["<stmt>"],
+        "<stmt>": ["<assgn> ; <stmt>", "<assgn>"],
+        "<assgn>": ["<var> := <rhs>"],
+    }
+"""
+        grammar_2_text = r"""
+from typing import Dict, List
+
+def grammar() -> Dict[str, List[str]]:
+    import string
+    return {
+        "<rhs>":
+            ["<var>", "<digit>"],
+        "<var>": list(string.ascii_lowercase),
+        "<digit>": list(string.digits)
+    }
+"""
+
+        grammar_file_1 = write_python_grammar_file(grammar_1_text)
+        grammar_file_2 = write_python_grammar_file(grammar_2_text)
+
+        constraint = """
+exists <assgn> assgn:
+  (before(assgn, <assgn>) and <assgn>.<rhs>.<var> = assgn.<var>)"""
+        constraint_file = write_constraint_file(constraint)
+
+        stdout, stderr, code = run_isla(
+            "solve",
+            grammar_file_1.name,
+            constraint_file.name,
+            grammar_file_2.name,
+            "-n",
+            -1,
+            "-t",
+            4,
+        )
+
+        print(stderr)
+        self.assertFalse(code)
+        self.assertFalse(stderr)
+        self.assertTrue(stdout)
+
+        solver = ISLaSolver(LANG_GRAMMAR, constraint)
+        for line in stdout.split("\n"):
+            self.assertTrue(solver.check(line))
+
+        grammar_file_1.close()
+        grammar_file_2.close()
+        constraint_file.close()
+
     def test_solve_assgn_lang_python_grammar(self):
         grammar_1_text = r"""
 grammar = {
@@ -309,6 +365,42 @@ exists <assgn> assgn:
 
         grammar_file_1.close()
         grammar_file_2.close()
+        constraint_file.close()
+
+    def test_solve_assgn_lang_invalid_python_grammar(self):
+        grammar_text = r"""
+grammar = {
+    "<start>":
+        "<stmt>",  # no list
+    "<stmt>":
+        ["<assgn> ; <stmt>", "<assgn>"],
+    "<assgn>":
+        ["<var> := <rhs>"],
+}
+"""
+
+        grammar_file = write_python_grammar_file(grammar_text)
+
+        constraint = """
+exists <assgn> assgn:
+  (before(assgn, <assgn>) and <assgn>.<rhs>.<var> = assgn.<var>)"""
+        constraint_file = write_constraint_file(constraint)
+
+        stdout, stderr, code = run_isla(
+            "solve",
+            grammar_file.name,
+            constraint_file.name,
+            "-n",
+            -1,
+            "-t",
+            4,
+        )
+
+        self.assertEqual(DATA_FORMAT_ERROR, code)
+        self.assertIn("A grammar must be of type `Dict[str, List[str]]`", stderr)
+        self.assertFalse(stdout)
+
+        grammar_file.close()
         constraint_file.close()
 
     def test_solve_assgn_lang_parameter_grammar(self):
@@ -1432,6 +1524,115 @@ exists <assgn> assgn:
 
         for line in stdout.split("\n"):
             self.assertTrue(solver.check(line))
+
+        grammar_file.close()
+        constraint_file.close()
+
+    def test_solve_additional_structural_predicate_not_callable(self):
+        grammar_file = write_grammar_file(LANG_GRAMMAR)
+
+        predicate_file = NamedTemporaryFile(suffix=".py")
+        predicate_file.write("predicates = set()\n".encode("utf-8"))
+        predicate_file.seek(0)
+
+        constraint = """
+exists <assgn> assgn:
+  (erofeb(assgn, <assgn>) and <assgn>.<rhs>.<var> = assgn.<var>)"""
+        constraint_file = write_constraint_file(constraint)
+
+        stdout, stderr, code = run_isla(
+            "solve",
+            grammar_file.name,
+            constraint_file.name,
+            predicate_file.name,
+            "-n",
+            -1,
+            "-t",
+            4,
+        )
+
+        self.assertEqual(DATA_FORMAT_ERROR, code)
+        self.assertIn(
+            "symbol `predicate` in Python extension file is not a function", stderr
+        )
+        self.assertFalse(stdout)
+
+        grammar_file.close()
+        constraint_file.close()
+
+    def test_solve_additional_structural_predicate_no_iterable(self):
+        grammar_file = write_grammar_file(LANG_GRAMMAR)
+
+        predicate_file_content = """
+def predicates():
+    return 13
+"""
+
+        predicate_file = NamedTemporaryFile(suffix=".py")
+        predicate_file.write(predicate_file_content.encode("utf-8"))
+        predicate_file.seek(0)
+
+        constraint = """
+exists <assgn> assgn:
+  (erofeb(assgn, <assgn>) and <assgn>.<rhs>.<var> = assgn.<var>)"""
+        constraint_file = write_constraint_file(constraint)
+
+        stdout, stderr, code = run_isla(
+            "solve",
+            grammar_file.name,
+            constraint_file.name,
+            predicate_file.name,
+            "-n",
+            -1,
+            "-t",
+            4,
+        )
+
+        self.assertEqual(DATA_FORMAT_ERROR, code)
+        self.assertIn(
+            "function `predicate` in Python extension file does not return an iterable",
+            stderr,
+        )
+        self.assertFalse(stdout)
+
+        grammar_file.close()
+        constraint_file.close()
+
+    def test_solve_additional_structural_predicate_no_predicates(self):
+        grammar_file = write_grammar_file(LANG_GRAMMAR)
+
+        predicate_file_content = """
+def predicates():
+    return [13]
+"""
+
+        predicate_file = NamedTemporaryFile(suffix=".py")
+        predicate_file.write(predicate_file_content.encode("utf-8"))
+        predicate_file.seek(0)
+
+        constraint = """
+exists <assgn> assgn:
+  (erofeb(assgn, <assgn>) and <assgn>.<rhs>.<var> = assgn.<var>)"""
+        constraint_file = write_constraint_file(constraint)
+
+        stdout, stderr, code = run_isla(
+            "solve",
+            grammar_file.name,
+            constraint_file.name,
+            predicate_file.name,
+            "-n",
+            -1,
+            "-t",
+            4,
+        )
+
+        self.assertEqual(DATA_FORMAT_ERROR, code)
+        self.assertIn(
+            "function `predicate` in Python extension file does not return an iterable "
+            + "of predicates",
+            stderr,
+        )
+        self.assertFalse(stdout)
 
         grammar_file.close()
         constraint_file.close()


### PR DESCRIPTION
### Added

- It is now possible to extend ISLa with custom structural or semantic predicates when
  using the CLI (this concerns `isla solve`, `isla parse`, `isla check`, `isla fuzz`,
  `isla mutate`, `isla find`, and `isla mutate`) by passing a Python file as input
  that contains a function

  ```python
  predicates() -> typing.Set[isla.language.StructuralPredicate | isla.language.SemanticPredicate]
  ```
  
  Additionally or alternatively, that file may define a variable `grammar` or a function
  `grammar()` specifying the grammar of the language under test. This behavior, already
  implemented in previous ISLa versions (for the variable declaration, see "Changed"),
  is unaffected by the predicate extension feature.

### Changed

- In Python extension files, grammars may *alternatively* be defined as the return
  value of a function `def grammar() -> Dict[str, List[str]]` instead of an assignment
  to a variable `grammar`. This is the preferred style; the variable assignment may get
  deprecated in the future.